### PR TITLE
[IENetherFishing]ネザー釣りで釣れるアイテムを追加。LootTableの構造変更

### DIFF
--- a/IENetherFishing/data/nether_fishing/loot_tables/nether_fishing_table.json
+++ b/IENetherFishing/data/nether_fishing/loot_tables/nether_fishing_table.json
@@ -1,53 +1,29 @@
 {
-    "pools": [
-      {
-        "rolls": 1,
-        "entries": [
-          {
-            "type": "minecraft:item",
-            "weight": 70,
-            "name": "minecraft:cooked_cod",
-            "functions": [
-              {
-                "function": "minecraft:set_nbt",
-                "tag": "{NetherFishTag:1,display:{Name:'{\"text\":\"溶岩魚\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"特定サーバーのネザーに生息すると言われている魚。\"}','{\"text\":\"とても熱い\"}']},CustomModelData:9001}"
-              }
-            ]
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 20,
-            "name": "minecraft:cooked_cod",
-            "functions": [
-              {
-                "function": "minecraft:set_nbt",
-                "tag": "{NetherFishTag:2,display:{Name:'{\"text\":\"ブレイズフィッシュ\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"特定サーバーのネザーに生息すると言われている魚。\"}','{\"text\":\"ブレイズとの関連性は不明\"}']},CustomModelData:9001}"
-              }
-            ]
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 9,
-            "name": "minecraft:cooked_cod",
-            "functions": [
-              {
-                "function": "minecraft:set_nbt",
-                "tag": "{NetherFishTag:3,display:{Name:'{\"text\":\"ウィザーフィッシュ\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"特定サーバーのネザーに生息すると言われている魚。\"}','{\"text\":\"マグマダイブで死亡したクラフターの\"}','{\"text\":\"怨念を糧にしていると言われている\"}']},CustomModelData:9001}"
-              }
-            ]
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 1,
-            "name": "minecraft:cooked_cod",
-            "functions": [
-              {
-                "function": "minecraft:set_nbt",
-                "tag": "{NetherFishTag:4,display:{Name:'{\"text\":\"ネザライトフィッシュ\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"特定サーバーのネザーに生息すると言われている魚。\"}','{\"text\":\"滅多に見ることはない幻の魚\"}']},CustomModelData:9001}"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "weight": 74,
+          "name": "nether_fishing:rewards/reward_table_common"
+        },
+        {
+          "type": "minecraft:loot_table",
+          "weight": 20,
+          "name": "nether_fishing:rewards/reward_table_uncommon"
+        },
+        {
+          "type": "minecraft:loot_table",
+          "weight": 5,
+          "name": "nether_fishing:rewards/reward_table_rare"
+        },
+        {
+          "type": "minecraft:loot_table",
+          "weight": 1,
+          "name": "nether_fishing:rewards/reward_table_epic"
+        }
+      ]
+    }
+  ]
+}

--- a/IENetherFishing/data/nether_fishing/loot_tables/rewards/reward_table_common.json
+++ b/IENetherFishing/data/nether_fishing/loot_tables/rewards/reward_table_common.json
@@ -1,0 +1,42 @@
+{
+    "pools": [
+      {
+        "rolls": 1,
+        "entries": [
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:cooked_cod",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:1,display:{Name:'{\"text\":\"溶岩魚\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"特定サーバーのネザーに生息すると言われている魚。\"}','{\"text\":\"とても熱い\"}']},CustomModelData:9001}"
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:cooked_chicken",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:1,display:{Name:'{\"text\":\"焼き鳥\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"ネザーに堕ちた鶏が焼けたもの。\"}','{\"text\":\"熱され過ぎて固い\"}']},CustomModelData:9002}"
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:cookie",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:1,display:{Name:'{\"text\":\"溶岩クッキー\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"溶岩の熱とガスとの涙で作られたクッキー\"}','{\"text\":\"\"}']},CustomModelData:9002}"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/IENetherFishing/data/nether_fishing/loot_tables/rewards/reward_table_epic.json
+++ b/IENetherFishing/data/nether_fishing/loot_tables/rewards/reward_table_epic.json
@@ -1,0 +1,42 @@
+{
+    "pools": [
+      {
+        "rolls": 1,
+        "entries": [
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:cooked_cod",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:4,display:{Name:'{\"text\":\"ネザライトフィッシュ\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"特定サーバーのネザーに生息すると言われている魚。\"}','{\"text\":\"滅多に見ることはない幻の魚\"}']},CustomModelData:9001}"
+              }
+            ]
+          } ,
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:rotten_flesh",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:1,display:{Name:'{\"text\":\"ゾンビピッグマンの死骸\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"絶滅したゾンビピッグマンの死骸。\"}','{\"text\":\"今なお死骸は朽ちず\"}']},CustomModelData:9003}"
+              }
+            ]
+          } ,
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:golden_apple",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:1,display:{Name:'{\"text\":\"金のリンゴ\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"ピグリンのお守り。\"}','{\"text\":\"普通に食べれる\"}']},CustomModelData:9003}"
+              }
+            ]
+          } 
+        ]
+      }
+    ]
+  }

--- a/IENetherFishing/data/nether_fishing/loot_tables/rewards/reward_table_rare.json
+++ b/IENetherFishing/data/nether_fishing/loot_tables/rewards/reward_table_rare.json
@@ -1,0 +1,42 @@
+{
+    "pools": [
+      {
+        "rolls": 1,
+        "entries": [
+          {
+            "type": "minecraft:item",
+            "weight": 9,
+            "name": "minecraft:cooked_cod",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:3,display:{Name:'{\"text\":\"ウィザーフィッシュ\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"特定サーバーのネザーに生息すると言われている魚。\"}','{\"text\":\"マグマダイブで死亡したクラフターの\"}','{\"text\":\"怨念を糧にしていると言われている\"}']},CustomModelData:9001}"
+              }
+            ]
+          } ,
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:baked_potato",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:1,display:{Name:'{\"text\":\"ポテトフライ\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"ネザー要塞で作られたﾎﾟﾃｲﾄｩﾌﾗｲ。\"}','{\"text\":\"ブレイズが原料\"}']},CustomModelData:9002}"
+              }
+            ]
+          } ,
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:rabbit_stew",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:1,display:{Name:'{\"text\":\"溶岩スープ\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"飲める溶岩。\"}','{\"text\":\"超特殊調理食材(噓)\"}']},CustomModelData:9002}"
+              }
+            ]
+          } 
+        ]
+      }
+    ]
+  }

--- a/IENetherFishing/data/nether_fishing/loot_tables/rewards/reward_table_uncommon.json
+++ b/IENetherFishing/data/nether_fishing/loot_tables/rewards/reward_table_uncommon.json
@@ -1,0 +1,42 @@
+{
+    "pools": [
+      {
+        "rolls": 1,
+        "entries": [
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:cooked_cod",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:2,display:{Name:'{\"text\":\"ブレイズフィッシュ\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"特定サーバーのネザーに生息すると言われている魚。\"}','{\"text\":\"ブレイズとの関連性は不明\"}']},CustomModelData:9001}"
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:cooked_beef",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:1,display:{Name:'{\"text\":\"調極厚炭化ステーキ\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"ネザーに堕ちた牛が焼けたもの。\"}','{\"text\":\"熱され過ぎてもはや炭\"}']},CustomModelData:9002}"
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:bread",
+            "functions": [
+              {
+                "function": "minecraft:set_nbt",
+                "tag": "{NetherFishTag:1,display:{Name:'{\"text\":\"地獄パン\",\"color\":\"dark_red\",\"bold\":true}',Lore:['{\"text\":\"ピグリンお手製のパン。\"}','{\"text\":\"おそらく遊泳中に落としたのだろう\"}']},CustomModelData:9002}"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
## 概要
- ネザー釣りのアイテムの種類で釣れるアイテムの種類を増加させました。
- また、ネザー釣りアイテムlootTableの構造を変更しました。

## 目的
- ネザー釣りで釣れるアイテムの種類を増やすオーダーが入ったため
- また、今後アイテムが増加した場合の抽選の重みづけを考慮した際に逐一重みづけを定義するものを簡略化するため

## 詳細

- ネザー釣りで得られるアイテムのloot定義を各レアリティ事に分割しました。<br>
  レアリティの定義に関しては一旦マインクラフトの希少度を参考に定義しています
  - reward_table_common.json<br>
    74%で釣れるアイテムを定義します。
  - reward_table_uncommon.json<br>
    20%で釣れるアイテムを定義します。
  - reward_table_rare.json<br>
    5%で釣れるアイテムを定義します。
  - reward_table_epic.json<br>
    1%で釣れるアイテムを定義します。


- 各テーブルにそれぞれ２種類のアイテムを追加定義し、釣れる数を４種類から１２種類に変更しました。

## 備考
- 今回定義したアイテムに関しては既存のアイテムにnbtタグによって名前と説明文の実を定義したダミーデータとなり、効果などを変更する場合は別途実装が必要になります。